### PR TITLE
Bugfix: pass  parameter from command() method by reference

### DIFF
--- a/lib/VarnishAdmin/VarnishAdminSocket.php
+++ b/lib/VarnishAdmin/VarnishAdminSocket.php
@@ -175,7 +175,7 @@ class VarnishAdminSocket implements VarnishAdmin
      * @throws Exception
      * @internal param $string
      */
-    protected function command($cmd, $code = '', $ok = 200)
+    protected function command($cmd, &$code = '', $ok = 200)
     {
         if (!$this->host) {
             return null;


### PR DESCRIPTION
Without this change you are unable to authorize properly.
