### PR TITLE
Backend.List and Authentication Fix

### DIFF
--- a/lib/VarnishAdmin/VarnishAdminSocket.php
+++ b/lib/VarnishAdmin/VarnishAdminSocket.php
@@ -241,6 +241,16 @@ class VarnishAdminSocket implements VarnishAdmin
     }
 
     /**
+     * Shortcut to backend list function.
+     *
+     * @return string
+     */
+    public function backendList()
+    {
+        return $this->command($this->commands->getBackendList());
+    }
+
+    /**
      * Shortcut to purge function.
      *
      * @see https://www.varnish-cache.org/docs/4.0/users-guide/purging.html
@@ -342,7 +352,8 @@ class VarnishAdminSocket implements VarnishAdmin
      */
     public function setSecret($secret)
     {
-        $this->secret = $secret;
+        // Secret requires a new line at the end, so if its not there, lets add it.
+        $this->secret = (strpos($secret, self::NEW_LINE) === (strlen($secret) - 1)) ? $secret : $secret.self::NEW_LINE;
     }
 
     /**

--- a/lib/VarnishAdmin/commands/Commands.php
+++ b/lib/VarnishAdmin/commands/Commands.php
@@ -9,6 +9,7 @@ abstract class Commands
     const START = 'start';
     const STATUS = 'status';
     const STOP = 'stop';
+    const BACKEND = 'backend';
     const BAN = 'ban';
     const AUTH = 'auth';
 

--- a/lib/VarnishAdmin/commands/CommandsVersion4.php
+++ b/lib/VarnishAdmin/commands/CommandsVersion4.php
@@ -19,4 +19,12 @@ class CommandsVersion4 extends Commands
     {
         return self::NUMBER;
     }
+
+    /**
+     * @return string
+     */
+    public function getBackendList()
+    {
+        return self::BACKEND . '.list';
+    }
 }

--- a/tests/VarnishAdminSocketTest.php
+++ b/tests/VarnishAdminSocketTest.php
@@ -158,7 +158,7 @@ class VarnishAdminSocketTest extends PHPUnit_Framework_TestCase
     public function testSetSecret()
     {
         $this->admin->setSecret('secret');
-        $this->assertEquals('secret', $this->admin->secret);
+        $this->assertEquals("secret\n", $this->admin->secret);
     }
 
     public function testStop()


### PR DESCRIPTION
1. Added backend.list command to VarnishAdmin and tested against Varnish 4.1.9

2. Fixed authentication where a Secret is provided with no newline.

I was getting an Authentication Failure without a NEW_LINE even though my secret file had NO newline at the end of the secret string, so this fix checks for one, and adds it if it doesn't exist.

Tested with Varnish 4.1.9