### PR TITLE
Added backend.list Command

### DIFF
--- a/lib/VarnishAdmin/VarnishAdminSocket.php
+++ b/lib/VarnishAdmin/VarnishAdminSocket.php
@@ -241,6 +241,47 @@ class VarnishAdminSocket implements VarnishAdmin
     }
 
     /**
+     * Shortcut to backend list function.
+     *
+     * @return string
+     *
+     * Example Output:
+     *
+     * Backend name                   Admin      Probe
+     * boot.web01                     probe      Healthy 6/6
+     * boot.web02                     probe      Healthy 6/6
+     * boot.web03                     probe      Healthy 3/6
+     */
+    public function backendList()
+    {
+        $response = $this->command($this->commands->getBackendList());
+        // Let's turn this result into a PHP object so its easier to use in Code.
+        $lines = explode(PHP_EOL, $response);
+        $respArr = array();
+        $i = 0;
+        $colArr;
+        $numCols;
+        foreach($lines as $line) {
+            $line = trim($line);
+            if($line != '') {
+                if($i === 0) {  // First line should be our columns, all others should be our values.
+                    $colArr = preg_split('/\s\s+/', $line);
+                    $numCols = count($colArr);
+                    $respArr = array_fill_keys($colArr, array());
+                    $i++;
+                } else {
+                    $lineArr = preg_split('/\s\s+/', $line);
+                    for($j = 0; $j < $numCols; $j++) {
+                        $key = $colArr[$j]; // Look up key
+                        $respArr[$key][] = $lineArr[$j];
+                    }
+                }
+            }
+        }
+        return $respArr;
+    }
+
+    /**
      * Shortcut to purge function.
      *
      * @see https://www.varnish-cache.org/docs/4.0/users-guide/purging.html

--- a/lib/VarnishAdmin/commands/Commands.php
+++ b/lib/VarnishAdmin/commands/Commands.php
@@ -9,6 +9,7 @@ abstract class Commands
     const START = 'start';
     const STATUS = 'status';
     const STOP = 'stop';
+    const BACKEND = 'backend';
     const BAN = 'ban';
     const AUTH = 'auth';
 

--- a/lib/VarnishAdmin/commands/CommandsVersion4.php
+++ b/lib/VarnishAdmin/commands/CommandsVersion4.php
@@ -19,4 +19,12 @@ class CommandsVersion4 extends Commands
     {
         return self::NUMBER;
     }
+
+    /**
+     * @return string
+     */
+    public function getBackendList()
+    {
+        return self::BACKEND . '.list';
+    }
 }


### PR DESCRIPTION
Added backend.list command to Varnish 4 Commands.  This  command allows you to list your configured Varnish backends similar to below:

Backend name               Admin      Probe
boot.web01                     probe      Healthy 6/6
boot.web02                     probe      Healthy 6/6
boot.web03                     probe      Sick 2/6

My code returns this output in an associative array where the KEY names are row 1 from above, and point to arrays that hold the respective values below the key.